### PR TITLE
Feature/remove geodata lookup

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -6,6 +6,8 @@ class GooleMapsMap {
     // spread sheet keys
     this.CITY_KEY = 'City';
     this.COUNTRY_KEY = 'Country';
+    this.LAT_KEY = 'Lat';
+    this.LNG_KEY = 'Lng';
     this.REGISTRATION_KEY = 'RegistrationLink';
     this.getCountryCode = getCountryCode;
     this.linkCountry = linkCountry;
@@ -29,32 +31,30 @@ class GooleMapsMap {
     });
 
     this.events.forEach((event) => {
-      this.getPosition(event[this.COUNTRY_KEY], event[this.CITY_KEY]).then((response) => {
-        return response.json();
-      }).then((result) => {
-        if (result.results.length === 0) {
-          return;
-        }
+      const eventPosition = { 
+        lat: parseFloat(event[this.LAT_KEY]), 
+        lng: parseFloat(event[this.LNG_KEY]),
+      };
+      console.log(eventPosition);
+      
+      if (eventPosition == { lat: 0, lng:0 }) {
+        console.error(`Position not found ${event}`);
+        return;
+      }
 
-        const position = result.results[0].geometry.location;
-        const marker = new google.maps.Marker({
-          position: position,
-          country: event[this.COUNTRY_KEY],
-          icon: 'http://chart.apis.google.com/chart?chst=d_map_pin_letter&chld=%E2%80%A2%7C6FB8D8'
-        });
-        marker.setMap(googleMapsMap);
-        if (this.linkCountry) {
-          google.maps.event.addListener(marker, 'click', () => {
-            const coutryId = this.getCountryCode(marker.country)
-              window.location.hash = coutryId;
-          });
-        }
+      const marker = new google.maps.Marker({
+        position: eventPosition,
+        country: event[this.COUNTRY_KEY],
+        icon: 'http://chart.apis.google.com/chart?chst=d_map_pin_letter&chld=%E2%80%A2%7C6FB8D8'
       });
+      marker.setMap(googleMapsMap);
+      if (this.linkCountry) {
+        google.maps.event.addListener(marker, 'click', () => {
+          const coutryId = this.getCountryCode(marker.country)
+            window.location.hash = coutryId;
+        });
+      }
     });
-  }
-
-  getPosition(country, city) {
-    return fetch(this.GEOCODE_API + `${city},${country}`);
   }
 
   getStyles() {

--- a/js/map.js
+++ b/js/map.js
@@ -35,7 +35,6 @@ class GooleMapsMap {
         lat: parseFloat(event[this.LAT_KEY]), 
         lng: parseFloat(event[this.LNG_KEY]),
       };
-      console.log(eventPosition);
       
       if (eventPosition == { lat: 0, lng:0 }) {
         console.error(`Position not found ${event}`);

--- a/js/map.js
+++ b/js/map.js
@@ -9,6 +9,7 @@ class GooleMapsMap {
     this.LAT_KEY = 'Lat';
     this.LNG_KEY = 'Lng';
     this.REGISTRATION_KEY = 'RegistrationLink';
+    this.MARKER_ICON = 'http://chart.apis.google.com/chart?chst=d_map_pin_letter&chld=%E2%80%A2%7C6FB8D8';
     this.getCountryCode = getCountryCode;
     this.linkCountry = linkCountry;
   }
@@ -44,13 +45,13 @@ class GooleMapsMap {
       const marker = new google.maps.Marker({
         position: eventPosition,
         country: event[this.COUNTRY_KEY],
-        icon: 'http://chart.apis.google.com/chart?chst=d_map_pin_letter&chld=%E2%80%A2%7C6FB8D8'
+        icon: this.MARKER_ICON,
       });
       marker.setMap(googleMapsMap);
       if (this.linkCountry) {
         google.maps.event.addListener(marker, 'click', () => {
-          const coutryId = this.getCountryCode(marker.country)
-            window.location.hash = coutryId;
+          const coutryId = this.getCountryCode(marker.country);
+          window.location.hash = coutryId;
         });
       }
     });


### PR DESCRIPTION
I wrote a [node service](https://github.com/lkappeler/geodata-fetcher) which is adding coordinates to the spreadsheet (data source of events) so we do not have to fetch them for every load.

This commit removes the lookup and uses the coordinates form the spreadsheet instead.
I executed the script locally so we have all coordinate for the currently existing events.

fixes #60

@MichaelKohler Can you setup the script on a server and execute it like every hour or so.